### PR TITLE
kni: paper over lint error, with a FIXME note

### DIFF
--- a/kni.js
+++ b/kni.js
@@ -50,7 +50,7 @@ function main() {
 
         var states;
         if (config.fromJson) {
-            states = JSON.parse(knicript);
+            states = JSON.parse(kniscripts[0]); // TODO test needed
 
         } else {
             var story = new Story();


### PR DESCRIPTION
Typo causes an unused var lint under eslint:recommended gate towards #15

But not sure what the right way to fix it is, since am a little unclear on the intended use case.

Ideally, this would be added as a missing / failing test, and then fixed; maybe @kriskowal can hum me a few bars of what that test would do?

Barring that, if this ends up being the last thing holding back eslint:recommended, will just land as this paper thin "fix".